### PR TITLE
Fixup: Remove silly inline layout style. This was ill advised.

### DIFF
--- a/somno/templates/_partials/somno_top_nav.html
+++ b/somno/templates/_partials/somno_top_nav.html
@@ -2,10 +2,7 @@
   <a class="somno-brand" href="/#/">
     S
   </a>
-
-  <div style="margin-left: -40%;">
-    {% include 'partials/_nav_search.html' %}
-  </div>
+  {% include 'partials/_nav_search.html' %}
   <div class="right-menu">
     <div class="patient-details" ng-show="episode && path_base != '/list/'">
       [[ episode.getFullName() ]]


### PR DESCRIPTION
Doesn't work at all when not on a widescreen monitor - only ever a temporary hack - let's kill it.